### PR TITLE
Traceloop and deepseek-coder 

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,9 @@ pip install -r requirements.txt
 ```
 4. Install, configure Ollama and connect to large language models via the Ollama server.
 - [Setup Ollama](./docs/OLLAMA.md)
+```bash
+ollama pull deepseek-coder
+```
 
 6. Set up your `secrets.toml` file under `.streamlit` directory and copy `example.secrets.toml` into `secrets.toml` and replace the keys
 ```

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ llama-index-llms-ollama
 jina
 llama-index-embeddings-jinaai
 mysqlclient
+traceloop-sdk

--- a/src/app.py
+++ b/src/app.py
@@ -2,7 +2,7 @@ import streamlit as st
 import nest_asyncio
 from rag import create_index, response
 from components.sidebar import side_info
-from components.utils import initialise_session_state
+from components.utils import initialize_session_state
 
 # Apply nest_asyncio to handle nested event loops
 nest_asyncio.apply()
@@ -11,7 +11,7 @@ nest_asyncio.apply()
 st.title("🔍: GitHub Repository Query Interface")
 # st.set_page_config(page_title="GitRepoPilot AI", page_icon="🌟")
 side_info()
-initialise_session_state()
+initialize_session_state()
 
 # Input for the GitHub repository URL
 repo_url = st.text_input("Enter GitHub repository URL (e.g., https://github.com/owner/repo)")

--- a/src/components/utils.py
+++ b/src/components/utils.py
@@ -14,7 +14,7 @@ def abort_chat(error_message: str):
     st.session_state.chat_aborted = True
     st.rerun()
 
-def initialise_session_state():
+def initialize_session_state():
     if "chat_aborted" not in st.session_state:
         st.session_state.chat_aborted = False
 

--- a/src/rag.py
+++ b/src/rag.py
@@ -1,3 +1,6 @@
+# import os
+# from traceloop.sdk import Traceloop
+# import time
 from llama_index.core import StorageContext, VectorStoreIndex
 from llama_index.readers.github import GithubRepositoryReader, GithubClient
 from llama_index.vector_stores.tidbvector import TiDBVectorStore
@@ -5,6 +8,14 @@ from llama_index.embeddings.jinaai import JinaEmbedding
 from llama_index.core import Settings
 from llama_index.llms.ollama import Ollama
 import streamlit as st
+
+
+# # Initialize Traceloop
+# Traceloop.init(
+#     app_name="GitRepoPilot",
+#     disable_batch=True,
+#     api_key=st.secrets["TRACELOOP_API_KEY"]  # Set this in your environment variables
+# )
 
 def initialize():
     """
@@ -81,10 +92,10 @@ def create_index(owner, repo):
         # Initialize TiDB vector store
         tidbvec = TiDBVectorStore(
             connection_string=tidb_connection_url,
-            table_name="repo_" + repo,
+            table_name="temp_repo_{owner}_{repo}",
             distance_strategy="cosine",
             vector_dimension=768,
-            drop_existing_table=False,
+            drop_existing_table=True,
         )
         
         # Initialize storage context and index
@@ -104,7 +115,7 @@ def create_index(owner, repo):
 # TODO: research metadata filters and possible use them if they make results better
 def response (index, query):
     query_engine = index.as_query_engine(
-    streaming=True,
-)
+        streaming=True,
+    )
     response = query_engine.query(query)
     return response

--- a/src/rag.py
+++ b/src/rag.py
@@ -70,7 +70,7 @@ def initialize():
     else:
         raise ValueError("Ollama server URL not found in secrets.")
 
-    Settings.llm = Ollama(model="llama3", request_timeout=360.0)
+    Settings.llm = Ollama(model="deepseek-coder", request_timeout=360.0)
 
     return github_client, tidb_connection_url
 


### PR DESCRIPTION
- Added traceloop to track performance of model (uncomment code in rag.py to use and add the API key)

- changed the Ollama model to deepseek-coder

To use run :

```bash
ollama pull deepseek-coder
```

This has given me significantly more sophisticated responses and somewhat shorter (but not much shorter) times. 